### PR TITLE
fix: Correct AttributeError in calendar view

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ class CravingApp:
         df = pd.DataFrame(all_entries)
         if not df.empty and 'timestamp' in df.columns:
             df['timestamp'] = pd.to_datetime(df['timestamp'])
-            month_df = df[df['timestamp'].dt.to_period('M') == self.current_date.to_period('M')]
+            month_df = df[df['timestamp'].dt.to_period('M') == pd.Period(self.current_date, 'M')]
         else:
             month_df = pd.DataFrame()
 


### PR DESCRIPTION
This commit fixes a runtime crash caused by an `AttributeError: 'datetime.datetime' object has no attribute 'to_period'`.

The error occurred in the `draw_calendar_view` function when filtering pandas DataFrame entries for the currently displayed month. The code was attempting to call the pandas-specific `.to_period('M')` method on a standard Python `datetime.datetime` object (`self.current_date`), which is not valid.

The fix resolves this by converting `self.current_date` to a pandas `Period` object using `pd.Period(self.current_date, 'M')` before the comparison. This ensures that both sides of the comparison are of the same pandas data type, allowing the filtering to work as intended and preventing the application from crashing.