### PR TITLE
Refine calendar templates for color skins

### DIFF
--- a/calendar_marks_manager.py
+++ b/calendar_marks_manager.py
@@ -2,10 +2,21 @@ import json
 import os
 from typing import Dict, Optional
 
+
+def _normalize_mark_value(value):
+    if isinstance(value, dict):
+        return {
+            "scale": str(value.get("scale", "")) if value.get("scale") is not None else "",
+            "template": str(value.get("template", "")) if value.get("template") is not None else "",
+        }
+    if isinstance(value, str):
+        return {"scale": value, "template": ""}
+    return {"scale": "", "template": ""}
+
 MARKS_FILE = 'calendar_marks.json'
 
 
-def _load_from_disk() -> Dict[str, Dict[str, str]]:
+def _load_from_disk() -> Dict[str, Dict[str, Dict[str, str]]]:
     if not os.path.exists(MARKS_FILE):
         return {}
     try:
@@ -18,37 +29,106 @@ def _load_from_disk() -> Dict[str, Dict[str, str]]:
     return {}
 
 
-def load_marks() -> Dict[str, Dict[str, str]]:
+def load_marks() -> Dict[str, Dict[str, Dict[str, str]]]:
     return _load_from_disk()
 
 
-def save_marks(marks: Dict[str, Dict[str, str]]) -> None:
+def save_marks(marks: Dict[str, Dict[str, Dict[str, str]]]) -> None:
     with open(MARKS_FILE, 'w', encoding='utf-8') as f:
         json.dump(marks, f, ensure_ascii=False, indent=2)
 
 
-def is_marked(date_key: str, symptom: str, marks: Optional[Dict[str, Dict[str, str]]] = None) -> bool:
-    marks = load_marks() if marks is None else marks
-    return symptom in marks.get(date_key, {})
-
-
-def get_template(date_key: str, symptom: str, marks: Optional[Dict[str, Dict[str, str]]] = None) -> Optional[str]:
+def is_marked(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> bool:
     marks = load_marks() if marks is None else marks
     day_marks = marks.get(date_key, {})
-    if symptom in day_marks:
-        return day_marks[symptom]
-    return None
+    if symptom not in day_marks:
+        return False
+    value = day_marks[symptom]
+    if isinstance(value, dict):
+        return True
+    if isinstance(value, str) and value:
+        return True
+    return isinstance(value, str)
 
 
-def set_mark(date_key: str, symptom: str, template: str = '', marks: Optional[Dict[str, Dict[str, str]]] = None) -> Dict[str, Dict[str, str]]:
+def get_mark(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Optional[Dict[str, str]]:
+    marks = load_marks() if marks is None else marks
+    day_marks = marks.get(date_key, {})
+    if symptom not in day_marks:
+        return None
+    value = day_marks[symptom]
+    normalized = _normalize_mark_value(value)
+    if normalized != value:
+        day_marks[symptom] = normalized
+        save_marks(marks)
+    return normalized
+
+
+def get_scale(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Optional[str]:
+    mark = get_mark(date_key, symptom, marks)
+    if mark is None:
+        return None
+    return mark.get("scale") or None
+
+
+def get_template_name(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Optional[str]:
+    mark = get_mark(date_key, symptom, marks)
+    if mark is None:
+        return None
+    return mark.get("template") or None
+
+
+def update_mark(
+    date_key: str,
+    symptom: str,
+    *,
+    scale: Optional[str] = None,
+    template: Optional[str] = None,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Dict[str, Dict[str, Dict[str, str]]]:
     marks = load_marks() if marks is None else marks
     day_marks = marks.setdefault(date_key, {})
-    day_marks[symptom] = template
+    current = _normalize_mark_value(day_marks.get(symptom, {}))
+    if scale is not None:
+        current["scale"] = scale
+    if template is not None:
+        current["template"] = template
+    day_marks[symptom] = current
     save_marks(marks)
     return marks
 
 
-def remove_mark(date_key: str, symptom: str, marks: Optional[Dict[str, Dict[str, str]]] = None) -> Dict[str, Dict[str, str]]:
+def set_mark(
+    date_key: str,
+    symptom: str,
+    scale: str = '',
+    template: str = '',
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Dict[str, Dict[str, Dict[str, str]]]:
+    return update_mark(date_key, symptom, scale=scale, template=template, marks=marks)
+
+
+def remove_mark(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Dict[str, Dict[str, Dict[str, str]]]:
     marks = load_marks() if marks is None else marks
     day_marks = marks.get(date_key)
     if day_marks and symptom in day_marks:


### PR DESCRIPTION
## Summary
- store calendar mark metadata with separate scale and template fields and normalize existing data
- allow templates to define background and foreground colors for calendar cells via settings
- apply selected template colors to calendar marks and expose scale/color choices in the cell menu

## Testing
- python -m py_compile main.py calendar_marks_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e24747e4c48323bad49747a2db8836