### PR TITLE
Remove calendar templates and boost readability

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -1,32 +1,114 @@
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from collections import Counter
+from itertools import combinations, product
+from datetime import datetime
 import data_manager
+
+
+def _split_triggers(trigger_string):
+    if not trigger_string:
+        return []
+    return [item.strip() for item in trigger_string.split(',') if item.strip()]
 
 def get_summary_stats(entries):
     """Calculates summary statistics from craving entries."""
     if not entries:
         return {
             "total_entries": 0,
-            "avg_intensity": 0,
+            "avg_intensity": "N/A",
             "most_common_trigger": "N/A",
-            "most_used_coping": "N/A"
+            "most_used_coping": "N/A",
+            "most_common_pair": "N/A",
+            "most_common_sequence": "N/A",
+            "workday_weekend_distribution": {"workdays": 0, "weekend": 0},
         }
 
     total_entries = len(entries)
-    avg_intensity = sum(int(e['intensity']) for e in entries) / total_entries
 
-    triggers = [e['triggers'] for e in entries if e['triggers']]
-    most_common_trigger = Counter(triggers).most_common(1)[0][0] if triggers else "N/A"
+    intensities = []
+    trigger_counts = Counter()
+    coping_mechanisms = []
+    for entry in entries:
+        try:
+            intensities.append(int(entry.get('intensity', 0)))
+        except (TypeError, ValueError):
+            pass
+        trigger_list = _split_triggers(entry.get('triggers', ''))
+        trigger_counts.update(trigger_list)
+        coping_value = entry.get('coping_mechanism')
+        if coping_value:
+            coping_mechanisms.append(coping_value)
 
-    coping_mechanisms = [e['coping_mechanism'] for e in entries if e['coping_mechanism']]
+    avg_intensity = f"{(sum(intensities) / len(intensities)):.2f}" if intensities else "N/A"
+    most_common_trigger = trigger_counts.most_common(1)[0][0] if trigger_counts else "N/A"
     most_used_coping = Counter(coping_mechanisms).most_common(1)[0][0] if coping_mechanisms else "N/A"
+
+    pair_counter = Counter()
+    for entry in entries:
+        trigger_list = sorted(set(_split_triggers(entry.get('triggers', ''))))
+        if len(trigger_list) < 2:
+            continue
+        for pair in combinations(trigger_list, 2):
+            pair_counter[pair] += 1
+
+    most_common_pair = "N/A"
+    if pair_counter:
+        pair, count = pair_counter.most_common(1)[0]
+        most_common_pair = f"{pair[0]} + {pair[1]} ({count})"
+
+    parsed_entries = []
+    for entry in entries:
+        timestamp = entry.get('timestamp')
+        try:
+            dt = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S") if timestamp else None
+        except ValueError:
+            try:
+                dt = datetime.fromisoformat(timestamp)
+            except (TypeError, ValueError):
+                dt = None
+        parsed_entries.append({
+            'datetime': dt,
+            'triggers': _split_triggers(entry.get('triggers', ''))
+        })
+
+    chronological_entries = [item for item in parsed_entries if item['datetime'] is not None]
+    chronological_entries.sort(key=lambda item: item['datetime'])
+
+    sequential_counter = Counter()
+    for first, second in zip(chronological_entries, chronological_entries[1:]):
+        first_triggers = first['triggers']
+        second_triggers = second['triggers']
+        if not first_triggers or not second_triggers:
+            continue
+        for combo in product(first_triggers, second_triggers):
+            sequential_counter[combo] += 1
+
+    most_common_sequence = "N/A"
+    if sequential_counter:
+        (first_trigger, second_trigger), count = sequential_counter.most_common(1)[0]
+        most_common_sequence = f"{first_trigger} → {second_trigger} ({count})"
+
+    workday_entries = 0
+    weekend_entries = 0
+    for item in chronological_entries:
+        dt = item['datetime']
+        if dt.weekday() < 5:
+            workday_entries += 1
+        else:
+            weekend_entries += 1
 
     return {
         "total_entries": total_entries,
-        "avg_intensity": f"{avg_intensity:.2f}",
+        "avg_intensity": avg_intensity,
         "most_common_trigger": most_common_trigger,
-        "most_used_coping": most_used_coping
+        "most_used_coping": most_used_coping,
+        "most_common_pair": most_common_pair,
+        "most_common_sequence": most_common_sequence,
+        "workday_weekend_distribution": {
+            "workdays": workday_entries,
+            "weekend": weekend_entries,
+        },
     }
 
 
@@ -38,8 +120,17 @@ def create_intensity_plot(parent_frame, entries):
     if not entries:
         return
 
-    timestamps = [e['timestamp'] for e in entries]
-    intensities = [int(e['intensity']) for e in entries]
+    timestamps = []
+    intensities = []
+    for entry in entries:
+        try:
+            intensities.append(int(entry['intensity']))
+            timestamps.append(entry['timestamp'])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    if not intensities:
+        return
 
     fig, ax = plt.subplots(figsize=(6, 4))
     ax.plot(timestamps, intensities, marker='o', linestyle='-')

--- a/calendar_marks_manager.py
+++ b/calendar_marks_manager.py
@@ -2,10 +2,21 @@ import json
 import os
 from typing import Dict, Optional
 
+
+def _normalize_mark_value(value):
+    if isinstance(value, dict):
+        scale = value.get("scale")
+        if scale is None and value.get("template"):
+            scale = ""
+        return {"scale": str(scale) if scale is not None else ""}
+    if isinstance(value, str):
+        return {"scale": value}
+    return {"scale": ""}
+
 MARKS_FILE = 'calendar_marks.json'
 
 
-def _load_from_disk() -> Dict[str, Dict[str, str]]:
+def _load_from_disk() -> Dict[str, Dict[str, Dict[str, str]]]:
     if not os.path.exists(MARKS_FILE):
         return {}
     try:
@@ -18,37 +29,91 @@ def _load_from_disk() -> Dict[str, Dict[str, str]]:
     return {}
 
 
-def load_marks() -> Dict[str, Dict[str, str]]:
+def load_marks() -> Dict[str, Dict[str, Dict[str, str]]]:
     return _load_from_disk()
 
 
-def save_marks(marks: Dict[str, Dict[str, str]]) -> None:
+def save_marks(marks: Dict[str, Dict[str, Dict[str, str]]]) -> None:
     with open(MARKS_FILE, 'w', encoding='utf-8') as f:
         json.dump(marks, f, ensure_ascii=False, indent=2)
 
 
-def is_marked(date_key: str, symptom: str, marks: Optional[Dict[str, Dict[str, str]]] = None) -> bool:
-    marks = load_marks() if marks is None else marks
-    return symptom in marks.get(date_key, {})
-
-
-def get_template(date_key: str, symptom: str, marks: Optional[Dict[str, Dict[str, str]]] = None) -> Optional[str]:
+def is_marked(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> bool:
     marks = load_marks() if marks is None else marks
     day_marks = marks.get(date_key, {})
-    if symptom in day_marks:
-        return day_marks[symptom]
-    return None
+    if symptom not in day_marks:
+        return False
+    value = day_marks[symptom]
+    if isinstance(value, dict):
+        return True
+    if isinstance(value, str) and value:
+        return True
+    return isinstance(value, str)
 
 
-def set_mark(date_key: str, symptom: str, template: str = '', marks: Optional[Dict[str, Dict[str, str]]] = None) -> Dict[str, Dict[str, str]]:
+def get_mark(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Optional[Dict[str, str]]:
+    marks = load_marks() if marks is None else marks
+    day_marks = marks.get(date_key, {})
+    if symptom not in day_marks:
+        return None
+    value = day_marks[symptom]
+    normalized = _normalize_mark_value(value)
+    if normalized != value:
+        day_marks[symptom] = normalized
+        save_marks(marks)
+    return normalized
+
+
+def get_scale(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Optional[str]:
+    mark = get_mark(date_key, symptom, marks)
+    if mark is None:
+        return None
+    return mark.get("scale") or None
+
+
+def update_mark(
+    date_key: str,
+    symptom: str,
+    *,
+    scale: Optional[str] = None,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Dict[str, Dict[str, Dict[str, str]]]:
     marks = load_marks() if marks is None else marks
     day_marks = marks.setdefault(date_key, {})
-    day_marks[symptom] = template
+    current = _normalize_mark_value(day_marks.get(symptom, {}))
+    if scale is not None:
+        current["scale"] = scale
+    day_marks[symptom] = current
     save_marks(marks)
     return marks
 
 
-def remove_mark(date_key: str, symptom: str, marks: Optional[Dict[str, Dict[str, str]]] = None) -> Dict[str, Dict[str, str]]:
+def set_mark(
+    date_key: str,
+    symptom: str,
+    scale: str = '',
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Dict[str, Dict[str, Dict[str, str]]]:
+    return update_mark(date_key, symptom, scale=scale, marks=marks)
+
+
+def remove_mark(
+    date_key: str,
+    symptom: str,
+    marks: Optional[Dict[str, Dict[str, Dict[str, str]]]] = None,
+) -> Dict[str, Dict[str, Dict[str, str]]]:
     marks = load_marks() if marks is None else marks
     day_marks = marks.get(date_key)
     if day_marks and symptom in day_marks:

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
+from tkinter import font as tkfont
 import data_manager
 import analysis
 import settings_manager
@@ -13,16 +14,34 @@ import subprocess
 import pandas as pd
 
 class CravingApp:
+    _ENTRY_TS_KEY = "_timestamp_dt"
+    _ENTRY_TRIGGERS_KEY = "_triggers_list"
+
     def __init__(self, root):
         self.root = root
         self.root.title("Dzienniczek Głodów Alkoholowych")
         self.root.geometry("1200x800")
         self.selected_symptoms = []
-        self.templates = []
+        self.font_size = 12
+        self.mark_background = "#ff6b6b"
+        self.mark_foreground = "#ffffff"
+        self._font_cache = {}
         self.cell_marks = calendar_marks_manager.load_marks()
         self.current_date = datetime.now()
+        self.scale_levels = [str(level) for level in range(1, 11)]
+        self.symptom_column_width = 200
+        self._resizing_symptom_column = False
+        self._resizer_width = 6
+        self._calendar_cells = []
+        self._cell_map = {}
+        self._current_month_triggers = {}
+        self._raw_entries = []
+        self._enriched_entries = []
+        self._month_trigger_cache = {}
 
         # --- Main Layout ---
+        self.style = ttk.Style()
+
         self.notebook = ttk.Notebook(root)
         self.notebook.pack(pady=10, padx=10, fill="both", expand=True)
 
@@ -42,80 +61,126 @@ class CravingApp:
         self.load_entries()
         reminder_scheduler.start_scheduler_thread()
 
+    def _update_font_cache(self):
+        base_size = max(12, int(self.font_size))
+        title_size = max(base_size + 4, 16)
+        if not self._font_cache:
+            self._font_cache = {
+                "base": tkfont.Font(family="Helvetica", size=base_size),
+                "bold": tkfont.Font(family="Helvetica", size=base_size, weight="bold"),
+                "title": tkfont.Font(family="Helvetica", size=title_size, weight="bold"),
+            }
+        else:
+            self._font_cache["base"].configure(size=base_size)
+            self._font_cache["bold"].configure(size=base_size)
+            self._font_cache["title"].configure(size=title_size)
+        self.root.option_add("*Font", self._font_cache["base"])
+
     def create_journal_widgets(self):
         control_frame = ttk.Frame(self.journal_frame)
         control_frame.pack(fill='x', padx=10, pady=5)
         ttk.Button(control_frame, text="< Poprzedni Miesiąc", command=self.prev_month).pack(side='left')
-        self.month_year_label = ttk.Label(control_frame, text="", font=("Helvetica", 14, "bold"))
+        self.month_year_label = ttk.Label(control_frame, text="", font=self._get_title_font())
         self.month_year_label.pack(side='left', expand=True)
         ttk.Button(control_frame, text="Następny Miesiąc >", command=self.next_month).pack(side='right')
 
         self.calendar_frame = ttk.Frame(self.journal_frame)
         self.calendar_frame.pack(fill="both", expand=True, padx=10, pady=10)
+        self.calendar_frame.bind("<Configure>", self._on_calendar_resize)
 
     def draw_calendar_view(self):
         for widget in self.calendar_frame.winfo_children():
             widget.destroy()
         self.month_year_label.config(text=self.current_date.strftime("%B %Y"))
 
-        all_entries = data_manager.load_cravings()
-        df = pd.DataFrame(all_entries)
-        if not df.empty and 'timestamp' in df.columns:
-            df['timestamp'] = pd.to_datetime(df['timestamp'])
-            month_df = df[df['timestamp'].dt.to_period('M') == pd.Period(self.current_date, 'M')]
-        else:
-            month_df = pd.DataFrame()
+        month_day_triggers = self._get_month_trigger_lookup(self.current_date)
+        self._current_month_triggers = month_day_triggers
 
         days_in_month = calendar.monthrange(self.current_date.year, self.current_date.month)[1]
+        self._days_in_current_month = days_in_month
 
-        ttk.Label(self.calendar_frame, text="Objaw / Wyzwalacz", font=("Helvetica", 10, "bold"), relief="solid", borderwidth=1, padding=5).grid(row=0, column=0, sticky="nsew")
+        self.symptom_labels = []
+        self._calendar_cells = []
+        self._cell_map = {}
+
+        header_label = ttk.Label(
+            self.calendar_frame,
+            text="Objaw / Wyzwalacz",
+            font=self._get_font(weight="bold"),
+            relief="solid",
+            borderwidth=1,
+            padding=5,
+            anchor="w"
+        )
+        header_label.grid(row=0, column=0, sticky="nsew")
+        header_label.configure(wraplength=self.symptom_column_width - 10)
+
+        resizer = tk.Frame(self.calendar_frame, width=self._resizer_width, cursor="sb_h_double_arrow", bg="#d0d0d0")
+        resizer.grid(row=0, column=1, rowspan=len(symptoms.SYMPTOM_LIST) + 1, sticky="ns")
+        resizer.bind("<ButtonPress-1>", self.start_resizing_symptom_column)
+        resizer.bind("<B1-Motion>", self.perform_resizing_symptom_column)
+        resizer.bind("<ButtonRelease-1>", self.finish_resizing_symptom_column)
+        self._symptom_header_label = header_label
 
         for day_num in range(1, days_in_month + 1):
             date = datetime(self.current_date.year, self.current_date.month, day_num)
-            day_button = ttk.Button(self.calendar_frame, text=str(day_num), command=lambda d=date: self.open_new_entry_window(d))
-            day_button.grid(row=0, column=day_num, sticky="nsew")
-
-        self.cell_marks = calendar_marks_manager.load_marks()
+            day_button = ttk.Button(
+                self.calendar_frame,
+                text=str(day_num),
+                command=lambda d=date: self.open_new_entry_window(d)
+            )
+            day_button.configure(style="Day.TButton")
+            day_button.grid(row=0, column=day_num + 1, sticky="nsew")
 
         for i, symptom in enumerate(symptoms.SYMPTOM_LIST, start=1):
-            symptom_label = ttk.Label(self.calendar_frame, text=symptom, wraplength=200, relief="solid", borderwidth=1, padding=5)
+            symptom_label = ttk.Label(
+                self.calendar_frame,
+                text=symptom,
+                wraplength=self.symptom_column_width - 10,
+                relief="solid",
+                borderwidth=1,
+                padding=5,
+                anchor="w",
+                font=self._get_font()
+            )
             symptom_label.grid(row=i, column=0, sticky="nsew")
+            self.symptom_labels.append(symptom_label)
             for day_num in range(1, days_in_month + 1):
-                cell_color = "#f0f0f0"
-                cell_text = ""
-                date_str = datetime(self.current_date.year, self.current_date.month, day_num).strftime("%Y-%m-%d")
-                mark_template = calendar_marks_manager.get_template(date_str, symptom, self.cell_marks)
-                if mark_template is not None:
-                    cell_color = "#ff7979"
-                    cell_text = mark_template if mark_template else "✓"
-                if not month_df.empty:
-                    day_entries = month_df[month_df['timestamp'].dt.day == day_num]
-                    if not day_entries.empty and 'triggers' in day_entries.columns:
-                        symptom_present = day_entries['triggers'].str.contains(symptom, na=False).any()
-                        if symptom_present:
-                            cell_color = "#ffb3b3" if mark_template is None else cell_color
-                cell = tk.Label(self.calendar_frame, bg=cell_color, relief="solid", borderwidth=1, text=cell_text)
-                cell.grid(row=i, column=day_num, sticky="nsew")
+                cell = tk.Label(
+                    self.calendar_frame,
+                    relief="solid",
+                    borderwidth=1,
+                    cursor="hand2"
+                )
+                cell.grid(row=i, column=day_num + 1, sticky="nsew")
                 cell.bind("<Button-1>", lambda e, s=symptom, d=day_num: self.handle_cell_click(e, s, d))
                 cell.bind("<Button-3>", lambda e, s=symptom, d=day_num: self.open_cell_menu(e, s, d))
-                cell.configure(cursor="hand2")
+                cell.bind("<Enter>", lambda e, c=cell: self._on_cell_enter(c))
+                cell.bind("<Leave>", lambda e, c=cell: self._on_cell_leave(c))
+                self._calendar_cells.append(cell)
+                self._cell_map[(symptom, day_num)] = cell
+                self._apply_cell_visuals(symptom, day_num, cell)
 
-        self.calendar_frame.grid_columnconfigure(0, weight=1, uniform="group1")
-        for col in range(1, days_in_month + 1):
+        self.calendar_frame.grid_columnconfigure(0, weight=0, minsize=self.symptom_column_width)
+        self.calendar_frame.grid_columnconfigure(1, weight=0, minsize=self._resizer_width)
+        for col in range(2, days_in_month + 2):
             self.calendar_frame.grid_columnconfigure(col, weight=1, uniform="group1")
         for row in range(len(symptoms.SYMPTOM_LIST) + 1):
             self.calendar_frame.grid_rowconfigure(row, weight=1, uniform="group1")
+        self._apply_current_fonts()
+
+        self.calendar_frame.after_idle(lambda: self._on_calendar_resize(None))
 
     def handle_cell_click(self, event, symptom, day_num):
+        if event:
+            event.widget.focus_set()
         date = datetime(self.current_date.year, self.current_date.month, day_num)
         date_str = date.strftime("%Y-%m-%d")
         if calendar_marks_manager.is_marked(date_str, symptom, self.cell_marks):
             self.cell_marks = calendar_marks_manager.remove_mark(date_str, symptom, self.cell_marks)
         else:
-            default_template = self.templates[0] if self.templates else ""
-            self.cell_marks = calendar_marks_manager.set_mark(date_str, symptom, default_template, self.cell_marks)
-        self.draw_calendar_view()
-        self.open_cell_menu(event, symptom, day_num, date_str=date_str)
+            self.cell_marks = calendar_marks_manager.set_mark(date_str, symptom, marks=self.cell_marks)
+        self._apply_cell_visuals(symptom, day_num)
 
     def open_cell_menu(self, event, symptom, day_num, date_str=None):
         if date_str is None:
@@ -125,28 +190,188 @@ class CravingApp:
         is_marked = calendar_marks_manager.is_marked(date_str, symptom, self.cell_marks)
         if is_marked:
             menu.add_command(label="Usuń zaznaczenie", command=lambda: self.remove_cell_mark(date_str, symptom))
-            if self.templates:
-                menu.add_separator()
-                for template in self.templates:
-                    menu.add_command(label=f"Ustaw szablon: {template}", command=lambda t=template: self.assign_template(date_str, symptom, t))
         else:
-            menu.add_command(label="Zaznacz głód", command=lambda: self.assign_template(date_str, symptom, self.templates[0] if self.templates else ""))
-            if self.templates:
-                menu.add_separator()
-                for template in self.templates:
-                    menu.add_command(label=f"Zaznacz jako: {template}", command=lambda t=template: self.assign_template(date_str, symptom, t))
+            menu.add_command(label="Zaznacz głód", command=lambda: self.add_basic_mark(date_str, symptom))
+
+        scale_menu = tk.Menu(menu, tearoff=0)
+        current_mark = calendar_marks_manager.get_mark(date_str, symptom, self.cell_marks)
+        current_value = current_mark.get("scale") if current_mark else None
+        if current_value:
+            menu.add_command(label=f"Aktualna skala: {current_value}", state="disabled")
+            menu.add_separator()
+        menu.add_cascade(label="Skala głodu", menu=scale_menu)
+        for level in self.scale_levels:
+            scale_menu.add_command(
+                label=f"{level}",
+                command=lambda l=level: self.assign_scale(date_str, symptom, l)
+            )
         try:
             menu.tk_popup(event.x_root, event.y_root)
         finally:
             menu.grab_release()
 
-    def assign_template(self, date_str, symptom, template):
-        self.cell_marks = calendar_marks_manager.set_mark(date_str, symptom, template, self.cell_marks)
-        self.draw_calendar_view()
+    def start_resizing_symptom_column(self, event):
+        self._resizing_symptom_column = True
+        self._resize_start_x = event.x_root
+        self._initial_symptom_width = self.symptom_column_width
+
+    def perform_resizing_symptom_column(self, event):
+        if not self._resizing_symptom_column:
+            return
+        delta = event.x_root - self._resize_start_x
+        new_width = max(80, self._initial_symptom_width + delta)
+        self.symptom_column_width = new_width
+        self.calendar_frame.grid_columnconfigure(0, minsize=self.symptom_column_width)
+        wrap_value = max(10, self.symptom_column_width - 10)
+        if hasattr(self, "_symptom_header_label"):
+            self._symptom_header_label.configure(wraplength=wrap_value)
+        for label in getattr(self, "symptom_labels", []):
+            label.configure(wraplength=wrap_value)
+        self._on_calendar_resize(None)
+
+    def finish_resizing_symptom_column(self, event):
+        self._resizing_symptom_column = False
+
+    def _on_cell_enter(self, cell):
+        original_bg = getattr(cell, "original_bg", cell.cget("bg"))
+        hover_color = self._calculate_hover_color(original_bg)
+        cell.configure(
+            bg=hover_color,
+            highlightthickness=max(2, getattr(cell, "original_highlightthickness", 1)),
+            highlightbackground="#333333"
+        )
+
+    def _on_cell_leave(self, cell):
+        cell.configure(
+            bg=getattr(cell, "original_bg", cell.cget("bg")),
+            highlightthickness=getattr(cell, "original_highlightthickness", 1),
+            highlightbackground=getattr(cell, "original_highlightbackground", "#b3b3b3")
+        )
+
+    def _calculate_hover_color(self, hex_color):
+        if not hex_color.startswith("#") or len(hex_color) not in (4, 7):
+            return "#d9d9d9"
+        if len(hex_color) == 4:
+            hex_color = "#" + "".join(ch * 2 for ch in hex_color[1:])
+        try:
+            r = int(hex_color[1:3], 16)
+            g = int(hex_color[3:5], 16)
+            b = int(hex_color[5:7], 16)
+        except ValueError:
+            return "#d9d9d9"
+        lighten = lambda component: min(255, int(component + (255 - component) * 0.35))
+        hover_r = lighten(r)
+        hover_g = lighten(g)
+        hover_b = lighten(b)
+        return f"#{hover_r:02x}{hover_g:02x}{hover_b:02x}"
+
+    def _on_calendar_resize(self, event):
+        days_in_month = getattr(self, "_days_in_current_month", 0)
+        if not days_in_month:
+            return
+        total_width = max(1, self.calendar_frame.winfo_width())
+        total_height = max(1, self.calendar_frame.winfo_height())
+        row_count = len(symptoms.SYMPTOM_LIST) + 1
+        if row_count <= 0:
+            return
+        available_width = max(1, total_width - self.symptom_column_width - self._resizer_width)
+        available_height = max(1, total_height)
+        cell_size = min(available_width / days_in_month, available_height / row_count)
+        cell_size = max(1, cell_size)
+        for col in range(2, days_in_month + 2):
+            self.calendar_frame.grid_columnconfigure(col, minsize=int(cell_size))
+        for row in range(0, len(symptoms.SYMPTOM_LIST) + 1):
+            self.calendar_frame.grid_rowconfigure(row, minsize=int(cell_size))
+        for cell in getattr(self, "_calendar_cells", []):
+            cell.original_bg = cell.original_bg if hasattr(cell, "original_bg") else cell.cget("bg")
+
+    def _normalize_font_size(self, value):
+        try:
+            size = int(value)
+        except (TypeError, ValueError):
+            size = self.font_size
+        return max(12, min(36, size))
+
+    def _get_font(self, weight="normal"):
+        self._update_font_cache()
+        if (weight or "").lower() == "bold":
+            return self._font_cache["bold"]
+        return self._font_cache["base"]
+
+    def _get_title_font(self):
+        self._update_font_cache()
+        return self._font_cache["title"]
+
+    def _apply_current_fonts(self):
+        self._update_font_cache()
+        if hasattr(self, "month_year_label"):
+            self.month_year_label.configure(font=self._get_title_font())
+        if hasattr(self, "style"):
+            self.style.configure("Day.TButton", font=self._get_font())
+        if hasattr(self, "_symptom_header_label"):
+            self._symptom_header_label.configure(font=self._get_font(weight="bold"))
+        for label in getattr(self, "symptom_labels", []):
+            label.configure(font=self._get_font())
+        for cell in getattr(self, "_calendar_cells", []):
+            cell.configure(font=self._get_font())
+
+    def _apply_cell_visuals(self, symptom, day_num, cell=None):
+        if cell is None:
+            cell = self._cell_map.get((symptom, day_num))
+        if cell is None:
+            return
+        date = datetime(self.current_date.year, self.current_date.month, day_num)
+        date_str = date.strftime("%Y-%m-%d")
+        mark_data = calendar_marks_manager.get_mark(date_str, symptom, self.cell_marks)
+        cell_color = "#f0f0f0"
+        text_color = "#000000"
+        cell_text = ""
+        if mark_data is not None:
+            scale_value = mark_data.get("scale")
+            cell_color = self.mark_background
+            text_color = self.mark_foreground
+            cell_text = scale_value if scale_value else "✓"
+        triggers_for_day = self._current_month_triggers.get(day_num)
+        if triggers_for_day and symptom in triggers_for_day and mark_data is None:
+            cell_color = "#ffb3b3"
+        self._update_font_cache()
+        cell.configure(bg=cell_color, fg=text_color, text=cell_text, font=self._get_font())
+        try:
+            initial_thickness = int(cell.cget("highlightthickness") or 0)
+        except (ValueError, tk.TclError, TypeError):
+            initial_thickness = 0
+        cell.original_highlightthickness = max(1, initial_thickness or 1)
+        cell.original_highlightbackground = "#b3b3b3"
+        cell.original_bg = cell_color
+        cell.original_fg = text_color
+        cell.configure(highlightthickness=cell.original_highlightthickness, highlightbackground="#b3b3b3")
+
+    def add_basic_mark(self, date_str, symptom):
+        self.cell_marks = calendar_marks_manager.set_mark(date_str, symptom, marks=self.cell_marks)
+        try:
+            day_num = int(date_str.split('-')[2])
+        except (IndexError, ValueError):
+            self.draw_calendar_view()
+            return
+        self._apply_cell_visuals(symptom, day_num)
+
+    def assign_scale(self, date_str, symptom, scale):
+        self.cell_marks = calendar_marks_manager.update_mark(date_str, symptom, scale=scale, marks=self.cell_marks)
+        try:
+            day_num = int(date_str.split('-')[2])
+        except (IndexError, ValueError):
+            self.draw_calendar_view()
+            return
+        self._apply_cell_visuals(symptom, day_num)
 
     def remove_cell_mark(self, date_str, symptom):
         self.cell_marks = calendar_marks_manager.remove_mark(date_str, symptom, self.cell_marks)
-        self.draw_calendar_view()
+        try:
+            day_num = int(date_str.split('-')[2])
+        except (IndexError, ValueError):
+            self.draw_calendar_view()
+            return
+        self._apply_cell_visuals(symptom, day_num)
 
     def prev_month(self):
         self.current_date -= pd.DateOffset(months=1)
@@ -221,6 +446,7 @@ class CravingApp:
             self.symptoms_display.config(state="disabled")
 
     def load_entries(self):
+        self._refresh_entries()
         self.draw_calendar_view()
         self.update_analysis_tab()
 
@@ -235,6 +461,12 @@ class CravingApp:
         self.common_trigger_label.grid(row=2, column=0, padx=5, pady=2, sticky="w")
         self.used_coping_label = ttk.Label(stats_frame, text="Najczęstszy sposób radzenia sobie: N/A")
         self.used_coping_label.grid(row=3, column=0, padx=5, pady=2, sticky="w")
+        self.common_pair_label = ttk.Label(stats_frame, text="Najczęstsza para wyzwalaczy: N/A")
+        self.common_pair_label.grid(row=4, column=0, padx=5, pady=2, sticky="w")
+        self.sequence_label = ttk.Label(stats_frame, text="Najczęstsza sekwencja dni: N/A")
+        self.sequence_label.grid(row=5, column=0, padx=5, pady=2, sticky="w")
+        self.weekday_weekend_label = ttk.Label(stats_frame, text="Dni robocze vs weekend: N/A")
+        self.weekday_weekend_label.grid(row=6, column=0, padx=5, pady=2, sticky="w")
         self.plot_frame = ttk.LabelFrame(self.analysis_frame, text="Wykres Intensywności")
         self.plot_frame.grid(row=1, column=0, padx=10, pady=10, sticky="nsew")
         ttk.Button(self.analysis_frame, text="Uruchom Zaawansowany Panel Analizy (Streamlit)", command=self.launch_streamlit).grid(row=2, column=0, pady=20)
@@ -242,13 +474,18 @@ class CravingApp:
         self.analysis_frame.rowconfigure(1, weight=1)
 
     def update_analysis_tab(self):
-        entries = data_manager.load_cravings()
-        if not entries: return
+        entries = list(self._raw_entries)
         stats = analysis.get_summary_stats(entries)
         self.total_entries_label.config(text=f"Liczba wpisów: {stats['total_entries']}")
         self.avg_intensity_label.config(text=f"Średnia intensywność: {stats['avg_intensity']}")
         self.common_trigger_label.config(text=f"Najczęstszy wyzwalacz: {stats['most_common_trigger']}")
         self.used_coping_label.config(text=f"Najczęstszy sposób radzenia sobie: {stats['most_used_coping']}")
+        self.common_pair_label.config(text=f"Najczęstsza para wyzwalaczy: {stats['most_common_pair']}")
+        self.sequence_label.config(text=f"Najczęstsza sekwencja dni: {stats['most_common_sequence']}")
+        distribution = stats.get('workday_weekend_distribution', {"workdays": 0, "weekend": 0})
+        self.weekday_weekend_label.config(
+            text=f"Dni robocze vs weekend: {distribution.get('workdays', 0)} / {distribution.get('weekend', 0)}"
+        )
         analysis.create_intensity_plot(self.plot_frame, entries)
 
     def launch_streamlit(self):
@@ -278,12 +515,21 @@ class CravingApp:
         ttk.Checkbutton(reminder_frame, text="Włącz codzienne przypomnienia", variable=self.reminders_enabled_var).grid(row=0, column=0, columnspan=2, padx=5, pady=5, sticky="w")
         ttk.Label(reminder_frame, text="Godzina przypomnienia (HH:MM):").grid(row=1, column=0, padx=5, pady=5, sticky="w")
         ttk.Entry(reminder_frame, textvariable=self.reminder_time_var).grid(row=1, column=1, padx=5, pady=5, sticky="w")
-        templates_frame = ttk.LabelFrame(self.settings_frame, text="Szablony zaznaczeń")
-        templates_frame.grid(row=2, column=0, padx=10, pady=10, sticky="ew")
-        ttk.Label(templates_frame, text="Podaj nazwy szablonów (jeden na linię):").grid(row=0, column=0, padx=5, pady=5, sticky="w")
-        self.templates_text = tk.Text(templates_frame, height=5, width=40)
-        self.templates_text.grid(row=1, column=0, padx=5, pady=5, sticky="ew")
-        templates_frame.columnconfigure(0, weight=1)
+        appearance_frame = ttk.LabelFrame(self.settings_frame, text="Wygląd")
+        appearance_frame.grid(row=2, column=0, padx=10, pady=10, sticky="ew")
+        ttk.Label(appearance_frame, text="Rozmiar czcionki (12-36):").grid(row=0, column=0, padx=5, pady=5, sticky="w")
+        self.font_size_var = tk.IntVar(value=self.font_size)
+        self.font_size_spinbox = tk.Spinbox(
+            appearance_frame,
+            from_=12,
+            to=36,
+            increment=1,
+            textvariable=self.font_size_var,
+            width=5,
+            wrap=False
+        )
+        self.font_size_spinbox.grid(row=0, column=1, padx=5, pady=5, sticky="w")
+        appearance_frame.columnconfigure(1, weight=1)
         ttk.Button(self.settings_frame, text="Zapisz Ustawienia", command=self.save_app_settings).grid(row=3, column=0, padx=10, pady=10)
         ttk.Button(self.settings_frame, text="Wyślij E-mail Testowy", command=self.send_test_email_action).grid(row=4, column=0, padx=10, pady=10)
 
@@ -296,22 +542,89 @@ class CravingApp:
         self.recipient_email_var.set(settings.get("recipient_email", ""))
         self.reminders_enabled_var.set(settings.get("reminders_enabled", False))
         self.reminder_time_var.set(settings.get("reminder_time", "20:00"))
-        self.templates = settings.get("templates", [])
-        if hasattr(self, 'templates_text'):
-            self.templates_text.delete("1.0", tk.END)
-            self.templates_text.insert(tk.END, "\n".join(self.templates))
-        self.draw_calendar_view()
+        self.font_size = self._normalize_font_size(settings.get("font_size", self.font_size))
+        if hasattr(self, "font_size_var"):
+            self.font_size_var.set(self.font_size)
+        self._apply_current_fonts()
 
     def save_app_settings(self):
-        try: port = int(self.smtp_port_var.get())
-        except ValueError: messagebox.showerror("Błąd", "Port SMTP musi być liczbą."); return
-        templates_raw = self.templates_text.get("1.0", tk.END) if hasattr(self, 'templates_text') else ""
-        templates = [line.strip() for line in templates_raw.splitlines() if line.strip()]
-        settings = {"smtp_server": self.smtp_server_var.get(), "smtp_port": port, "smtp_user": self.smtp_user_var.get(), "smtp_password": self.smtp_password_var.get(), "recipient_email": self.recipient_email_var.get(), "reminders_enabled": self.reminders_enabled_var.get(), "reminder_time": self.reminder_time_var.get(), "templates": templates}
-        self.templates = templates
+        try:
+            port = int(self.smtp_port_var.get())
+        except ValueError:
+            messagebox.showerror("Błąd", "Port SMTP musi być liczbą.")
+            return
+        font_size_value = self._normalize_font_size(self.font_size_var.get() if hasattr(self, 'font_size_var') else self.font_size)
+        self.font_size = font_size_value
+        settings = {
+            "smtp_server": self.smtp_server_var.get(),
+            "smtp_port": port,
+            "smtp_user": self.smtp_user_var.get(),
+            "smtp_password": self.smtp_password_var.get(),
+            "recipient_email": self.recipient_email_var.get(),
+            "reminders_enabled": self.reminders_enabled_var.get(),
+            "reminder_time": self.reminder_time_var.get(),
+            "font_size": font_size_value,
+        }
         settings_manager.save_settings(settings)
-        messagebox.showinfo("Sukces", "Ustawienia zostały zapisane. Aplikacja może wymagać ponownego uruchomienia, aby zmiany w harmonogramie zostały zastosowane.")
+        self._apply_current_fonts()
+        messagebox.showinfo(
+            "Sukces",
+            "Ustawienia zostały zapisane. Aplikacja może wymagać ponownego uruchomienia, aby zmiany w harmonogramie zostały zastosowane."
+        )
         self.draw_calendar_view()
+
+    def _refresh_entries(self):
+        raw_entries = data_manager.load_cravings()
+        self._raw_entries = raw_entries
+        enriched = []
+        for entry in raw_entries:
+            entry_copy = dict(entry)
+            parsed_timestamp = self._parse_timestamp(entry_copy.get('timestamp'))
+            triggers_list = self._split_triggers(entry_copy.get('triggers', ''))
+            entry_copy[self._ENTRY_TS_KEY] = parsed_timestamp
+            entry_copy[self._ENTRY_TRIGGERS_KEY] = triggers_list
+            enriched.append(entry_copy)
+        self._enriched_entries = enriched
+        self._month_trigger_cache.clear()
+
+    def _parse_timestamp(self, timestamp_value):
+        if isinstance(timestamp_value, datetime):
+            return timestamp_value
+        if timestamp_value in (None, ""):
+            return None
+        for parser in (
+            lambda value: datetime.strptime(value, "%Y-%m-%d %H:%M:%S"),
+            lambda value: datetime.fromisoformat(value),
+        ):
+            try:
+                return parser(str(timestamp_value))
+            except (ValueError, TypeError):
+                continue
+        return None
+
+    def _split_triggers(self, trigger_string):
+        if not trigger_string:
+            return []
+        return [item.strip() for item in str(trigger_string).split(',') if item.strip()]
+
+    def _get_month_trigger_lookup(self, date):
+        key = (date.year, date.month)
+        cached = self._month_trigger_cache.get(key)
+        if cached is not None:
+            return cached
+        trigger_map = {}
+        for entry in self._enriched_entries:
+            timestamp = entry.get(self._ENTRY_TS_KEY)
+            if not timestamp or timestamp.year != date.year or timestamp.month != date.month:
+                continue
+            triggers = entry.get(self._ENTRY_TRIGGERS_KEY, [])
+            if not triggers:
+                continue
+            day_triggers = trigger_map.setdefault(timestamp.day, set())
+            day_triggers.update(triggers)
+        frozen_map = {day: frozenset(values) for day, values in trigger_map.items()}
+        self._month_trigger_cache[key] = frozen_map
+        return frozen_map
 
     def send_test_email_action(self):
         result = email_notifier.send_email("Testowy e-mail z Dzienniczka Głodów Alkoholowych", "To jest testowa wiadomość, aby sprawdzić, czy ustawienia e-mail są poprawne.")

--- a/settings_manager.py
+++ b/settings_manager.py
@@ -11,7 +11,7 @@ DEFAULT_SETTINGS = {
     "recipient_email": "",
     "reminders_enabled": False,
     "reminder_time": "20:00",
-    "templates": []
+    "font_size": 12,
 }
 
 def load_settings():


### PR DESCRIPTION
## Summary
- remove the calendar template color system and simplify mark storage to scale-only records
- refresh calendar rendering to use a consistent highlight color and provide a basic mark toggle from the context menu
- raise the default and minimum font sizes and streamline settings so typography stays legible across the app

## Testing
- python -m py_compile main.py analysis.py calendar_marks_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e24747e4c48323bad49747a2db8836